### PR TITLE
added lagrangian multiplers output

### DIFF
--- a/lib/quadprog.js
+++ b/lib/quadprog.js
@@ -85,7 +85,7 @@ function dpofa(a, lda, n, info) {
     }
 }
 
-function qpgen2(dmat, dvec, fddmat, n, sol, crval, amat,
+function qpgen2(dmat, dvec, fddmat, n, sol, lagr, crval, amat,
     bvec, fdamat, q, meq, iact, nact, iter, work, ierr) {
 
     var i, j, l, l1, info, it1, iwzv, iwrv, iwrm, iwsv, iwuv, nvl, r, iwnbv,
@@ -112,6 +112,7 @@ function qpgen2(dmat, dvec, fddmat, n, sol, crval, amat,
     }
     for (i = 1; i <= q; i = i + 1) {
         iact[i] = 0;
+        lagr[i] = 0;
     }
 
     info = [];
@@ -208,6 +209,9 @@ function qpgen2(dmat, dvec, fddmat, n, sol, crval, amat,
             }
         }
         if (nvl === 0) {
+            for (i = 1; i <= nact; i = i + 1) {
+                lagr[iact[i]] = work[iwuv + i];
+            }
             return 999;
         }
 
@@ -515,7 +519,7 @@ function qpgen2(dmat, dvec, fddmat, n, sol, crval, amat,
 function solveQP(Dmat, dvec, Amat, bvec, meq, factorized) {
     var i, n, q,
         nact, r,
-        crval = [], iact = [], sol = [], work = [], iter = [],
+        crval = [], iact = [], sol = [], lagr = [], work = [], iter = [],
         message;
 
     meq = meq || 0;
@@ -533,6 +537,7 @@ function solveQP(Dmat, dvec, Amat, bvec, meq, factorized) {
     }
     for (i = 1; i <= q; i = i + 1) {
         iact[i] = 0;
+        lagr[i] = 0;
     }
     nact = 0;
     r = Math.min(n, q);
@@ -547,7 +552,7 @@ function solveQP(Dmat, dvec, Amat, bvec, meq, factorized) {
         iter[i] = 0;
     }
 
-    qpgen2(Dmat, dvec, n, n, sol, crval, Amat,
+    qpgen2(Dmat, dvec, n, n, sol, lagr, crval, Amat,
         bvec, n, q, meq, iact, nact, iter, work, factorized);
 
     message = "";
@@ -560,6 +565,7 @@ function solveQP(Dmat, dvec, Amat, bvec, meq, factorized) {
 
     return {
         solution: sol,
+	lagrangians: lagr,
         value: crval,
         unconstrained_solution: dvec,
         iterations: iter,


### PR DESCRIPTION
I'm not sure which version of the qpgen2() FORTRAN code you started from, but it appears that there is another variation that includes Lagrange multipliers in the output. My Mac version of R includes the Lagrange multipliers as well.

For an example of this version of qpgen2() look at https://github.com/Chromatical/node-quadprog-native/blob/master/src/solve.QP.f

This diff passes your test script. The multipliers for the first example correspond to the R result on my Mac. I don't think that adding the multipliers will break any existing code.
